### PR TITLE
Server Side Validation

### DIFF
--- a/force-app/main/default/aura/googleRecaptcha/googleRecaptcha.cmp
+++ b/force-app/main/default/aura/googleRecaptcha/googleRecaptcha.cmp
@@ -10,6 +10,7 @@
     <aura:attribute name="secretKey" type="String" default="6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe" />
     <aura:attribute name="allowedURLs" type="String[]" />
     <aura:attribute name="frameTitle" type="String" />
+    <aura:attribute name="flowGuid" type="String" />
 
     <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
 

--- a/force-app/main/default/aura/googleRecaptcha/googleRecaptcha.design
+++ b/force-app/main/default/aura/googleRecaptcha/googleRecaptcha.design
@@ -8,4 +8,5 @@
     <design:attribute name="secretKey" label="Recaptcha Secret Key" description="Your secret key generated for your domain" />
     <design:attribute name="siteKey" label="Recaptcha Site Key" description="Your site key generated for your domain" />
     <design:attribute name="frameTitle" label="Recaptcha Frame Title (optional)" description="Provide a meaningful title of the recaptcha frame for screenreaders (accessibility)" />
+    <design:attribute name="flowGuid" label="Flow Interview GUID" description="Pass in the {!$Flow.InterviewGuid} to support server side validation."  />
 </design:component>

--- a/force-app/main/default/aura/googleRecaptcha/googleRecaptchaController.js
+++ b/force-app/main/default/aura/googleRecaptcha/googleRecaptchaController.js
@@ -85,7 +85,11 @@
                     cmp.set("v.recaptchaResponse", data);
                     
                     // Create the server side apex verification
-                    var params = {"recaptchaResponse" : cmp.get("v.recaptchaResponse"), "recaptchaSecretKey" : cmp.get("v.secretKey")};
+                    var params = {
+                        "recaptchaResponse" : cmp.get("v.recaptchaResponse"), 
+                        "recaptchaSecretKey" : cmp.get("v.secretKey"),
+                        "flowInterviewGuid": cmp.get("v.flowGuid")
+                    };
                     helper.sendRequest(cmp, 'c.isVerified', params)
                     .then($A.getCallback(function(records) {
                         // If verified positive                    

--- a/force-app/main/default/cachePartitions/GoogleRecaptchaVerification.cachePartition-meta.xml
+++ b/force-app/main/default/cachePartitions/GoogleRecaptchaVerification.cachePartition-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PlatformCachePartition xmlns="http://soap.sforce.com/2006/04/metadata">
+    <isDefaultPartition>false</isDefaultPartition>
+    <masterLabel>GoogleRecaptchaVerification</masterLabel>
+    <platformCachePartitionTypes>
+        <allocatedCapacity>0</allocatedCapacity>
+        <allocatedPartnerCapacity>0</allocatedPartnerCapacity>
+        <allocatedPurchasedCapacity>0</allocatedPurchasedCapacity>
+        <allocatedTrialCapacity>0</allocatedTrialCapacity>
+        <cacheType>Session</cacheType>
+    </platformCachePartitionTypes>
+    <platformCachePartitionTypes>
+        <allocatedCapacity>5</allocatedCapacity>
+        <allocatedPartnerCapacity>0</allocatedPartnerCapacity>
+        <allocatedPurchasedCapacity>0</allocatedPurchasedCapacity>
+        <allocatedTrialCapacity>0</allocatedTrialCapacity>
+        <cacheType>Organization</cacheType>
+    </platformCachePartitionTypes>
+</PlatformCachePartition>

--- a/force-app/main/default/classes/GoogleRecaptchaHandler.cls
+++ b/force-app/main/default/classes/GoogleRecaptchaHandler.cls
@@ -13,7 +13,7 @@ public with sharing class GoogleRecaptchaHandler {
     } 
         
     @AuraEnabled
-    public static Boolean isVerified(String recaptchaResponse, String recaptchaSecretKey){
+    public static Boolean isVerified(String recaptchaResponse, String recaptchaSecretKey, String flowInterviewGuid){
         Http http = new Http();
         HttpRequest request = new HttpRequest();
         request.setEndpoint('https://www.google.com/recaptcha/api/siteverify');
@@ -25,7 +25,11 @@ public with sharing class GoogleRecaptchaHandler {
             System.debug(response.getBody());
             Map<String, Object> result = (Map<String, Object>) JSON.deserializeUntyped(response.getBody());
 
-            if (result.containsKey('success') && result.get('success') == true) {                
+            if (result.containsKey('success') && result.get('success') == true) {      
+                
+                // Log validation of the submitted 
+                logValidation(flowInterviewGuid);
+
                 return true;      
             } else {
                 return false;
@@ -33,5 +37,52 @@ public with sharing class GoogleRecaptchaHandler {
         }
         
         return false;
+    }
+    
+    public static void logValidation (String flowInterviewGuid) {
+
+        // Insert a unique reference for the Flow Interview ID
+        try {
+            insert new Google_reCAPTCHA_Validation__c(
+                Name = processFlowInterviewGuid(flowInterviewGuid)
+            );
+        }
+        catch (Exception ex) {
+            system.debug('### Already validated');
+        }
+    }
+
+    // Validate the Google reCAPTCHA has been submitted
+    @InvocableMethod (label='Validate reCAPTCHA' description='Use the Flow Interview ID to validate the reCAPTCHA has been submitted by user')
+    public static List<Boolean> validateRecaptcha(List<String> flowIntervewGuids) {  
+        
+        List<Boolean> validated = new List<Boolean>();
+
+        for (String flowInterviewGuid :flowIntervewGuids) {
+
+            // Retrieve the verification record
+            Google_reCAPTCHA_Validation__c captchaValidation = 
+                Google_reCAPTCHA_Validation__c.getInstance(processFlowInterviewGuid(flowInterviewGuid));
+
+            // If we have a valid validation record
+            if (captchaValidation != null) {
+
+                validated.add(true);
+
+                // Once we've verified the reCAPTCHA, we can delete it.
+                delete captchaValidation;
+            }
+            else {
+
+                validated.add(false); 
+            }
+        }
+
+        return validated;
+    }
+
+    // Limit flowInterviewGuid to 38 chars as that is max for custom setting name
+    public static String processFlowInterviewGuid(String flowInterviewGuid) {
+        return flowInterviewGuid.split('-')[0].left(38);
     }
 }

--- a/force-app/main/default/classes/GoogleRecaptchaHandler.cls
+++ b/force-app/main/default/classes/GoogleRecaptchaHandler.cls
@@ -27,8 +27,8 @@ public with sharing class GoogleRecaptchaHandler {
 
             if (result.containsKey('success') && result.get('success') == true) {      
                 
-                // Log validation of the submitted 
-                logValidation(flowInterviewGuid);
+                // Store in platform cache
+                Cache.Org.put(getCacheKey(flowInterviewGuid), DateTime.now());
 
                 return true;      
             } else {
@@ -39,19 +39,6 @@ public with sharing class GoogleRecaptchaHandler {
         return false;
     }
     
-    public static void logValidation (String flowInterviewGuid) {
-
-        // Insert a unique reference for the Flow Interview ID
-        try {
-            insert new Google_reCAPTCHA_Validation__c(
-                Name = processFlowInterviewGuid(flowInterviewGuid)
-            );
-        }
-        catch (Exception ex) {
-            system.debug('### Already validated');
-        }
-    }
-
     // Validate the Google reCAPTCHA has been submitted
     @InvocableMethod (label='Validate reCAPTCHA' description='Use the Flow Interview ID to validate the reCAPTCHA has been submitted by user')
     public static List<Boolean> validateRecaptcha(List<String> flowIntervewGuids) {  
@@ -60,17 +47,13 @@ public with sharing class GoogleRecaptchaHandler {
 
         for (String flowInterviewGuid :flowIntervewGuids) {
 
-            // Retrieve the verification record
-            Google_reCAPTCHA_Validation__c captchaValidation = 
-                Google_reCAPTCHA_Validation__c.getInstance(processFlowInterviewGuid(flowInterviewGuid));
-
             // If we have a valid validation record
-            if (captchaValidation != null) {
+            if (Cache.Org.contains(getCacheKey(flowInterviewGuid))) {
 
                 validated.add(true);
 
-                // Once we've verified the reCAPTCHA, we can delete it.
-                delete captchaValidation;
+                // Remove the cache
+                Cache.Org.remove(getCacheKey(flowInterviewGuid));
             }
             else {
 
@@ -81,8 +64,7 @@ public with sharing class GoogleRecaptchaHandler {
         return validated;
     }
 
-    // Limit flowInterviewGuid to 38 chars as that is max for custom setting name
-    public static String processFlowInterviewGuid(String flowInterviewGuid) {
-        return flowInterviewGuid.split('-')[0].left(38);
+    public static String getCacheKey(String flowInterviewGuid) {
+        return 'local.GoogleRecaptchaVerification.' + flowInterviewGuid.split('-')[0];
     }
 }

--- a/force-app/main/default/classes/GoogleRecaptchaHandler.cls
+++ b/force-app/main/default/classes/GoogleRecaptchaHandler.cls
@@ -10,7 +10,7 @@ public with sharing class GoogleRecaptchaHandler {
         allowedURLs.add(URL.getOrgDomainUrl().toExternalForm().replace('.my.salesforce.com', '--c.visualforce.com'));
 
         return allowedURLs;
-    }
+    } 
         
     @AuraEnabled
     public static Boolean isVerified(String recaptchaResponse, String recaptchaSecretKey){

--- a/force-app/main/default/classes/GoogleRecaptchaHandlerTest.cls
+++ b/force-app/main/default/classes/GoogleRecaptchaHandlerTest.cls
@@ -4,7 +4,7 @@ global with sharing class GoogleRecaptchaHandlerTest {
     @IsTest static void testIsVerified() {
         Test.setMock(HttpCalloutMock.class, new GoogleRecaptchaHandlerTest.RecaptchaHttpCalloutMock());
 
-        System.assert(GoogleRecaptchaHandler.isVerified('8djkfhsdfjsd49234734', '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'));
+        System.assert(GoogleRecaptchaHandler.isVerified('8djkfhsdfjsd49234734', '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe', 'XXX'));
     }
 
     @IsTest static void testFetchBaseURL() {

--- a/force-app/main/default/objects/Google_reCAPTCHA_Validation__c/Google_reCAPTCHA_Validation__c.object-meta.xml
+++ b/force-app/main/default/objects/Google_reCAPTCHA_Validation__c/Google_reCAPTCHA_Validation__c.object-meta.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
-    <customSettingsType>List</customSettingsType>
-    <enableFeeds>false</enableFeeds>
-    <label>Google reCAPTCHA Validation</label>
-    <visibility>Public</visibility>
-</CustomObject>

--- a/force-app/main/default/objects/Google_reCAPTCHA_Validation__c/Google_reCAPTCHA_Validation__c.object-meta.xml
+++ b/force-app/main/default/objects/Google_reCAPTCHA_Validation__c/Google_reCAPTCHA_Validation__c.object-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customSettingsType>List</customSettingsType>
+    <enableFeeds>false</enableFeeds>
+    <label>Google reCAPTCHA Validation</label>
+    <visibility>Public</visibility>
+</CustomObject>


### PR DESCRIPTION
Following comments from the issue raised here:
https://github.com/clifford-fra/GoogleRecaptchav2/issues/4

This PR addresses a major security concern whereby the server-side validation is easily bypassed by a bot. We implemented this reCAPTCHA for a government client and it failed penetration testing as programatically we were able to submit forms without a user ever being verified by reCAPTCHA.

This fix works as follows:
1. The Screen Flow passes its $Flow.InterviewGuid value into the reCAPTCHA component
2. On successful validation of the reCAPTCHA, a Org Cache value is inserted using the Flow.InterviewGuid 
3. Within the next node of the Flow, we query for the existence of the Org Cache value and only continue if one can be verified

**How to pass variable into component:**
![Screen Shot 2022-02-10 at 1 13 11 PM](https://user-images.githubusercontent.com/4425026/153312260-c5e0c30a-e93c-4173-9645-e0335d94656a.png)

**Apex action to verify reCAPTCHA completion AFTER screen component**
![Screen Shot 2022-02-10 at 1 13 31 PM](https://user-images.githubusercontent.com/4425026/153312293-0f6f2e4d-4d8e-4aa5-a97f-8deea8fdab48.png)

**Decision node to continue Flow if validated**
![Screen Shot 2022-02-10 at 1 13 49 PM](https://user-images.githubusercontent.com/4425026/153312328-949b3910-4ab3-45f1-8c9d-31a40c47d3ef.png)

